### PR TITLE
Fix mysql binary logging perms error

### DIFF
--- a/release/docker-compose.yml
+++ b/release/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     container_name: csweb
   mysql:
     image: mysql:${MYSQL_VERSION:-latest}
-    command: ['--default-authentication-plugin=mysql_native_password']
+    command: ['--default-authentication-plugin=mysql_native_password', '--log-bin-trust-function-creators=true']
     restart: always
     ports:
       - "3306:3306"


### PR DESCRIPTION
When adding a dictionary via web interface got a 500 error and see this error in the api log:
`General error: 1419 You do not have the SUPER privilege and binary logging is enabled (you *might* want to use the less safe log_bin_trust_function_creators variable)`

This PR attempts to fix it by adding `--log_bin_trust_function_creators=true` to the mysql startup arguments. This fixes the problem for me. I'm not sure what the security or other implications are of this change so feel to ignore this PR and implement a better solution. Just wanted a place to signal the issue.

My environment: 
* Docker CSWeb: latest main branch with no local changes
* Docker version 20.10.13, build a224086
* MacOS 14.2.1 (23C71)